### PR TITLE
[Add] public-itemslist-search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,5 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+gem "kaminari"

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,5 +1,17 @@
 class Public::ItemsController < Public::ApplicationController
+  allow_unauthenticated_access only: %i[index show]
+
   def index
+    @genres = Genre.all
+    if params[:genre_id]
+      @genre = Genre.find(params[:genre_id])
+      @items = @genre.items.where(is_active: true).page(params[:page])
+      @genre_name = @genre.name
+    else
+      @items = Item.where(is_active: true).page(params[:page])
+      @genre_name = "商品"
+    end
+    @items_count = @items.total_count
   end
 
   def show

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,2 +1,3 @@
 class Genre < ApplicationRecord
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,3 @@
 class Item < ApplicationRecord
+  belongs_to :genre
 end

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,2 +1,37 @@
-<h1>Public::Items#index</h1>
-<p>Find me in app/views/public/items/index.html.erb</p>
+<div class="d-flex">
+
+  <%# 左サイドバー：ジャンル検索 %>
+  <div class="border p-3 me-4" style="min-width: 150px;">
+    <p class="fw-bold text-center">ジャンル検索</p>
+    <% @genres.each do |genre| %>
+      <p><%= link_to genre.name, items_path(genre_id: genre.id) %></p>
+    <% end %>
+  </div>
+
+  <%# メインコンテンツ %>
+  <div class="flex-grow-1">
+    <h4>
+      <%= @genre_name %>一覧（全<%= @items_count %>件）
+    </h4>
+
+    <div class="row row-cols-4 g-4">
+      <% @items.each do |item| %>
+        <div class="col">
+          <%= link_to item_path(item), class: "text-decoration-none text-dark" do %>
+            <div>
+              <%# 画像は後で実装 %>
+              <div class="bg-secondary" style="width: 100%; aspect-ratio: 1;"></div>
+              <p class="mt-2 mb-0"><%= item.name %></p>
+              <p>¥<%= item.price.to_s(:delimited) %></p>
+            </div>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
+</div>
+
+<div class="d-flex justify-content-center mt-4">
+  <%= paginate @items %>
+</div>


### PR DESCRIPTION
## 対応内容

### 商品一覧ページ（/items）
- 販売中の商品を一覧表示
- 商品画像・商品名・価格を表示
- 画像未登録の場合は灰色のボックスを表示

### ジャンル検索機能
- 左サイドバーにジャンル一覧を表示
- ジャンルをクリックすると該当ジャンルの商品のみ表示

### ページネーション
- kaminari gemを使用して実装
- 1ページあたり8件表示指定

### モデルの修正
- Item モデルに `has_one_attached :image` を追加
- Item モデルに `paginates_per 8` を追加
- Item モデルに `belongs_to :genre` を追加
- Genre モデルに `has_many :items` を追加