### PR TITLE
[Add] admin_items_index_detail_edit_update

### DIFF
--- a/app/controllers/admin/items_controller.rb
+++ b/app/controllers/admin/items_controller.rb
@@ -1,5 +1,6 @@
 class Admin::ItemsController < Admin::ApplicationController
   def index
+    @items = Item.all.page(params[:page])
   end
 
   def new
@@ -18,12 +19,22 @@ class Admin::ItemsController < Admin::ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
   end
 
   def edit
+    @item = Item.find(params[:id])
+    @genres = Genre.all
   end
 
   def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to admin_item_path(@item), notice: "商品情報を更新しました"
+    else
+      @genres = Genre.all
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,2 +1,48 @@
-<h1>Admin::Items#edit</h1>
-<p>Find me in app/views/admin/items/edit.html.erb</p>
+<span class="bg-light px-3 fs-5 fw-bold">商品編集</span>
+
+<%= form_with model: @item, url: admin_item_path(@item), method: :patch, local: true do |f| %>
+  <table class="table table-borderless w-75 mt-3">
+    <tbody>
+      <tr>
+        <th class="table-light">商品画像</th>
+        <td><%= f.file_field :image %></td>
+      </tr>
+      <tr>
+        <th class="table-light">商品名</th>
+        <td><%= f.text_field :name, class: "form-control" %></td>
+      </tr>
+      <tr>
+        <th class="table-light">商品説明</th>
+        <td><%= f.text_area :introduction, class: "form-control", rows: 5 %></td>
+      </tr>
+      <tr>
+        <th class="table-light">ジャンル</th>
+        <td>
+          <%= f.collection_select :genre_id, @genres, :id, :name,
+            {},
+            { class: "form-select w-50" } %>
+        </td>
+      </tr>
+      <tr>
+        <th class="table-light">税抜価格</th>
+        <td>
+          <div class="d-flex align-items-center gap-2">
+            <%= f.number_field :price, class: "form-control w-25" %>
+            <span>円</span>
+          </div>
+        </td>
+      </tr>
+      <tr>
+        <th class="table-light">販売ステータス</th>
+        <td>
+          <%= f.radio_button :is_active, true %> 販売中
+          <%= f.radio_button :is_active, false %> 販売停止中
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <div class="text-center">
+    <%= f.submit "変更を保存", class: "btn btn-success px-5" %>
+  </div>
+<% end %>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -1,2 +1,37 @@
-<h1>Admin::Items#index</h1>
-<p>Find me in app/views/admin/items/index.html.erb</p>
+<div class="d-flex justify-content-between align-items-center">
+  <span class="bg-light px-3 fs-5 fw-bold">商品一覧</span>
+  <%= link_to "+", admin_items_new_path, class: "btn btn-outline-secondary" %>
+</div>
+
+<table class="table table-borderless mt-3 ">
+  <thead>
+    <tr class="table-light">
+      <th>商品ID</th>
+      <th>商品名</th>
+      <th>税抜価格</th>
+      <th>ジャンル</th>
+      <th>ステータス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @items.each do |item| %>
+      <tr>
+        <td><%= item.id %></td>
+        <td><%= link_to item.name, admin_item_path(item) %></td>
+        <td><%= number_with_delimiter(item.price) %></td>
+        <td><%= item.genre.name %></td>
+        <td>
+          <% if item.is_active %>
+            <span class="text-success fw-bold">販売中</span>
+          <% else %>
+            <span class="text-secondary">販売停止中</span>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="d-flex justify-content-center mt-4">
+  <%= paginate @items %>
+</div>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,2 +1,51 @@
-<h1>Admin::Items#show</h1>
-<p>Find me in app/views/admin/items/show.html.erb</p>
+<span class="bg-light px-3 fs-5 fw-bold">商品詳細</span>
+
+<div class="d-flex gap-5 mt-4">
+  <%# 商品画像 %>
+  <div>
+    <% if @item.image.attached? %>
+      <%= image_tag @item.image, style: "width: 250px; height: 250px; object-fit: cover;" %>
+    <% else %>
+      <div class="bg-secondary" style="width: 250px; height: 250px;"></div>
+    <% end %>
+  </div>
+
+  <%# 商品情報 %>
+  <table class="table table-borderless w-50">
+    <tbody>
+      <tr>
+        <th class="text-muted">商品名</th>
+        <td><%= @item.name %></td>
+      </tr>
+      <tr>
+        <th class="text-muted">商品説明</th>
+        <td><%= @item.introduction %></td>
+      </tr>
+      <tr>
+        <th class="text-muted">ジャンル</th>
+        <td><%= @item.genre.name %></td>
+      </tr>
+      <tr>
+        <th class="text-muted">税込価格（税抜価格）</th>
+        <td>
+          <%= number_with_delimiter((@item.price * 1.1).ceil) %>
+          （<%= number_with_delimiter(@item.price) %>）円
+        </td>
+      </tr>
+      <tr>
+        <th class="text-muted">販売ステータス</th>
+        <td>
+          <% if @item.is_active %>
+            <span class="text-success fw-bold">販売中</span>
+          <% else %>
+            <span class="text-secondary">販売停止中</span>
+          <% end %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="text-center mt-3">
+  <%= link_to "編集する", edit_admin_item_path(@item), class: "btn btn-success px-5" %>
+</div>


### PR DESCRIPTION
## 対応内容

### 商品一覧ページ（/admin/items）
- 全商品を一覧表示（商品ID・商品名・税抜価格・ジャンル・ステータス）
- kaminariページネーションを実装
- 新規登録ページへのリンクを設置

### 商品詳細ページ（/admin/items/:id）
- 商品画像・商品名・商品説明・ジャンル・税込価格（税抜価格）・販売ステータスを表示
- 税込価格は税抜価格×1.1を切り上げで計算
- 編集ページへのリンクを設置

### 商品編集ページ（/admin/items/:id/edit）
- 既存の商品情報をフォームに表示
- 商品画像・商品名・商品説明・ジャンル・税抜価格・販売ステータスを編集可能