### PR TITLE
[Add] public_top-page_about-page

### DIFF
--- a/app/controllers/public/homes_controller.rb
+++ b/app/controllers/public/homes_controller.rb
@@ -1,5 +1,9 @@
 class Public::HomesController < Public::ApplicationController
+  allow_unauthenticated_access only: %i[top about]
+
   def top
+    @genres = Genre.all
+    @items = Item.where(is_active: true).order(created_at: :desc).limit(4)
   end
 
   def about

--- a/app/views/public/homes/about.html.erb
+++ b/app/views/public/homes/about.html.erb
@@ -1,2 +1,10 @@
-<h1>Public::Homes#about</h1>
-<p>Find me in app/views/public/homes/about.html.erb</p>
+<div class="text-center mt-5">
+  <h1>About</h1>
+
+  <p class="mt-4">
+    ながのCAKEは全国発送可能なケーキ屋さんです。<br>
+    お子様からお年寄りの方までお召し上がりいただけるよう、<br>
+    様々なバリエーションをご用意しております。<br>
+    また、全国へ発送可能ですので「いつ」でも「どこ」でもご注文いただけます。<br>
+    ぜひご注文ください。
+  </p>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -1,2 +1,48 @@
-<h1>Public::Homes#top</h1>
-<p>Find me in app/views/public/homes/top.html.erb</p>
+<div class="d-flex">
+
+  <%# 左サイドバー：ジャンル検索 %>
+  <div class="border p-3 me-4" style="min-width: 150px;">
+    <p class="fw-bold text-center">ジャンル検索</p>
+    <% @genres.each do |genre| %>
+      <p><%= link_to genre.name, items_path(genre_id: genre.id) %></p>
+    <% end %>
+  </div>
+
+  <%# メインコンテンツ %>
+  <div class="flex-grow-1">
+
+    <%# メインビジュアル %>
+    <div class="border p-5 mb-4 text-center position-relative" style="min-height: 200px;">
+      <div class="border p-3 d-inline-block">
+        <p class="mb-0">ようこそ、ながのCAKEへ！</p>
+        <p class="mb-0">このサイトは、ケーキ販売のECサイトになります。</p>
+        <p class="mb-0">会員でない方も商品の閲覧はできますが、</p>
+        <p class="mb-0">購入には会員登録が必要になります。</p>
+      </div>
+    </div>
+
+    <%# 新着商品 %>
+    <h4>新着商品</h4>
+    <div class="row row-cols-4 g-4">
+      <% @items.each do |item| %>
+        <div class="col">
+          <%= link_to item_path(item), class: "text-decoration-none text-dark" do %>
+            <% if item.image.attached? %>
+              <%= image_tag item.image, style: "width: 100%; aspect-ratio: 1; object-fit: cover;" %>
+            <% else %>
+              <div class="bg-secondary" style="width: 100%; aspect-ratio: 1;"></div>
+            <% end %>
+            <p class="mt-2 mb-0 fw-bold"><%= item.name %></p>
+            <p>¥<%= number_with_delimiter(item.price) %></p>
+          <% end %>
+        </div>
+      <% end %>
+    </div>
+
+    <%# 全ての商品を見るリンク %>
+    <div class="text-end mt-3">
+      <%= link_to "全ての商品を見る ＞", items_path %>
+    </div>
+
+  </div>
+</div>


### PR DESCRIPTION
## 対応内容

### TOPページ（/）
- 左サイドバーにジャンル検索を表示
- メインビジュアルにサイト説明文を表示
- 新着商品を最新4件表示（画像・商品名・価格）
- 「全ての商品を見る」リンクを設置

### Aboutページ（/about）
- サイトの説明文を表示
- 画像エリアを設置（後で差し替え予定）

### コントローラーの修正
- `allow_unauthenticated_access` を追加（非ログイン時も閲覧可能）