### PR TITLE
[Add] my_page_display_modifying

### DIFF
--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,5 +1,5 @@
 class Public::RegistrationsController < Public::ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
+  allow_unauthenticated_access only: %i[new create]
 
   def new
     @customer = Customer.new
@@ -18,6 +18,17 @@ class Public::RegistrationsController < Public::ApplicationController
   private
 
   def customer_params
-    params.require(:customer).permit(:email_address, :password, :password_confirmation)
+    params.require(:customer).permit(
+      :email_address,
+      :password,
+      :password_confirmation,
+      :last_name,
+      :first_name,
+      :last_name_kana,
+      :first_name_kana,
+      :postal_code,
+      :address,
+      :phone_number
+    )
   end
 end


### PR DESCRIPTION
### バグ修正
- 新規登録時に名前・住所などが保存されない不具合を修正
- `customer_params` に不足していたカラムを追加

#### 追加したカラム
- last_name（姓）
- first_name（名）
- last_name_kana（姓カナ）
- first_name_kana（名カナ）
- postal_code（郵便番号）
- address（住所）
- phone_number（電話番号）

## 原因
ストロングパラメーターで `email_address` と `password` のみ許可していたため、
その他のカラムがDBに保存されていなかった。