### PR TITLE
Fix redirect to my page after registration

### DIFF
--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -9,7 +9,7 @@ class Public::RegistrationsController < Public::ApplicationController
     @customer = Customer.new(customer_params)
     if @customer.save
       start_new_session_for @customer
-      redirect_to root_path
+      redirect_to customers_my_page_path
     else
       render :new, status: :unprocessable_entity
     end


### PR DESCRIPTION
## 修正内容
会員登録後のリダイレクト先をトップページからマイページに変更しました。

## 原因
registrations_controller.rb の create アクションで
redirect_to root_path となっていたため

## 修正箇所
app/controllers/public/registrations_controller.rb
redirect_to root_path → redirect_to customers_my_page_path