### PR TITLE
Fix price calculation to include tax

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -9,7 +9,7 @@ class Public::OrdersController < Public::ApplicationController
     @order.customer = current_customer
     @cart_items = current_customer.cart_items
     @order.shopping_cost = 800
-    @order.total_payment = @cart_items.sum { |c| c.item.price * c.amount } + 800
+    @order.total_payment = @cart_items.sum { |c| (c.item.price * 1.1).ceil * c.amount } + 800
     if @order.valid?
       render :confirm
     else
@@ -25,7 +25,7 @@ class Public::OrdersController < Public::ApplicationController
       OrderDetail.create(
         order_id: @order.id,
         item_id: cart_item.item_id,
-        price: cart_item.item.price,
+        price: (cart_item.item.price * 1.1).ceil,
         amount: cart_item.amount
       )
       end

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -19,14 +19,14 @@
       <% @cart_items.each do |cart_item| %>
         <tr>
           <td><%= cart_item.item.name %></td>
-          <td><%= cart_item.item.price %>円</td>
+          <td><%= number_with_delimiter((cart_item.item.price * 1.1).ceil) %>円</td>
           <td>
             <%= form_with model: cart_item do |f| %>
             <%= f.number_field :amount, min: 1, value: cart_item.amount %>
             <%= f.submit "変更", class: "btn btn-success" %>
             <% end %>
           </td>
-          <td><%= cart_item.item.price * cart_item.amount %>円</td>
+          <td><%= number_with_delimiter(((cart_item.item.price * 1.1).ceil * cart_item.amount)) %>円</td>
           <td>
             <%= link_to "削除する", cart_item_path(cart_item), data: { turbo_method: :delete, turbo_confirm: "削除しますか？" }, class: "btn btn-danger" %>
           </td>
@@ -35,7 +35,7 @@
     </tbody>
   </table>
 
-  <p>合計金額：<%= @cart_items.sum { |cart_item| cart_item.item.price * cart_item.amount }%>円</p>
+  <p>合計金額：<%= number_with_delimiter(@cart_items.sum { |cart_item| (cart_item.item.price * 1.1).ceil * cart_item.amount }) %>円</p>
 <% end %>
 
 <%= link_to "買い物を続ける", items_path, class: "btn btn-primary" %>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -28,7 +28,7 @@
               <div class="bg-secondary" style="width: 100%; aspect-ratio: 1;"></div>
             <% end %>
             <p class="mt-2 mb-0 fw-bold"><%= item.name %></p>
-            <p>¥<%= number_with_delimiter(item.price) %></p>
+            <p>¥<%= number_with_delimiter((item.price * 1.1).ceil) %></p>
           <% end %>
         </div>
       <% end %>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -20,7 +20,7 @@
                 <div class="bg-secondary" style="width: 100%; aspect-ratio: 1;"></div>
               <% end %>
               <p class="mt-2 mb-0"><%= item.name %></p>
-              <p>¥<%= number_with_delimiter(item.price) %></p>
+              <p>¥<%= number_with_delimiter((item.price * 1.1).ceil) %></p>
             </div>
           <% end %>
         </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -18,7 +18,7 @@
     <div>
       <h4><%= @item.name %></h4>
       <p><%= @item.introduction %></p>
-      <p class="fs-5">¥ <%= number_with_delimiter(@item.price) %>（税込）</p>
+      <p class="fs-5">¥ <%= number_with_delimiter((@item.price * 1.1).ceil) %>（税込）</p>
 
       <%# カートに入れるフォーム（ログイン時のみ） %>
       <% if current_customer %>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -13,9 +13,9 @@
     <% @cart_items.each do |cart_item| %>
       <tr>
         <td><%= cart_item.item.name %></td>
-        <td><%= cart_item.item.price %>円</td>
+        <td><%= number_with_delimiter((cart_item.item.price * 1.1).ceil) %>円</td>
         <td><%= cart_item.amount %></td>
-        <td><%= cart_item.item.price * cart_item.amount %>円</td>
+        <td><%= number_with_delimiter(((cart_item.item.price * 1.1).ceil * cart_item.amount)) %>円</td>
       </tr>
     <% end %>
   </tbody>
@@ -28,7 +28,7 @@
   </tr>
   <tr>
     <th>商品合計</th>
-    <td><%= @cart_items.sum { |c| c.item.price * c.amount } %>円</td>
+    <td><%= number_with_delimiter(@cart_items.sum { |c| (c.item.price * 1.1).ceil * c.amount }) %>円</td>
   </tr>
   <tr>
     <th>請求金額</th>


### PR DESCRIPTION
## 修正内容
税抜価格で表示されていた箇所を税込価格（×1.1）に修正しました。

## 修正箇所
- トップページ（homes/top.html.erb）
- 商品一覧ページ（items/index.html.erb）
- 商品詳細ページ（items/show.html.erb）
- カート画面（cart_items/index.html.erb）
- 注文確認画面（orders/confirm.html.erb）
- 注文確定処理（orders_controller.rb）
  → order_detailsに税込価格を保存するよう修正

## 備考
- 注文履歴の価格は注文時点の税込価格をDBに保存する方式に変更
- 税率は10%（×1.1）、端数は切り上げ