### PR TITLE
Fix duplicate cart items

### DIFF
--- a/app/controllers/public/cart_items_controller.rb
+++ b/app/controllers/public/cart_items_controller.rb
@@ -4,12 +4,14 @@ class Public::CartItemsController < Public::ApplicationController
   end
 
   def create
-    @cart_item = current_customer.cart_items.new(cart_item_params)
-    if @cart_item.save
-      redirect_to cart_items_path
+    @cart_item = current_customer.cart_items.find_by(item_id: params[:cart_item][:item_id])
+    if @cart_item
+      @cart_item.update(amount: @cart_item.amount + params[:cart_item][:amount].to_i)
     else
-      render :index, status: :unprocessable_entity
+      @cart_item = current_customer.cart_items.new(cart_item_params)
+      @cart_item.save
     end
+    redirect_to cart_items_path
   end
 
   def update


### PR DESCRIPTION
## 修正内容
同じ商品をカートに追加した際、
新しい行が追加されていた挙動を修正しました。

## 原因
cart_items_controller.rb の create アクションで
既存のカートアイテムを確認せずに新規作成していたため

## 修正内容
カートに同じ商品がある場合は個数を加算し、
ない場合のみ新規作成するよう変更しました。

## 修正箇所
app/controllers/public/cart_items_controller.rb