### PR TITLE
Hide order button when cart is empty

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -40,4 +40,6 @@
 
 <%= link_to "買い物を続ける", root_path, class: "btn btn-primary" %>
 
-<%= link_to "情報入力に進む", orders_new_path, class: "btn btn-success" %>
+<% if @cart_items.present? %>
+  <%= link_to "情報入力に進む", orders_new_path, class: "btn btn-success" %>
+<% end %>


### PR DESCRIPTION
## 修正内容
カートが空の時に「情報入力に進む」ボタンを
非表示にしました。

## 修正箇所
app/views/public/cart_items/index.html.erb