### PR TITLE
Adjust admin panel layout and add search bar to header

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -1,7 +1,7 @@
 class Admin::CustomersController < Admin::ApplicationController
   def index
     @customers = if params[:search].present?
-      Customer.where("email_address LIKE ?", "%#{params[:search]}%")
+      Customer.where("email_address LIKE ?", "%#{params[:search]}%").per(10)
     else
       Customer.all
     end.page(params[:page])

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,6 +1,6 @@
 class Admin::OrdersController < Admin::ApplicationController
   def index
-    @orders = Order.all.order(created_at: :desc).page(params[:page])
+    @orders = Order.all.order(created_at: :desc).page(params[:page]).per(10)
   end
 
   def show

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -1,47 +1,55 @@
-<h3><%= @customer.last_name + @customer.first_name + "さんの会員情報編集" %></h3>
+<span class="bg-light px-3 fs-5 fw-bold"><%= @customer.last_name + @customer.first_name %>さんの会員情報編集</span>
 
 <%= form_with model: @customer, url: admin_customer_update_path(@customer) do |f| %>
-<table>
-  <tr>
-    <th>会員ID</th>
-    <td><%= @customer.id %></td>
-  </tr>
-  <tr>
-    <th>氏名</th>
-    <td><%= f.text_field :last_name %></td>
-    <td><%= f.text_field :first_name %></td>
-  </tr>
-  <tr>
-    <th>フリガナ</th>
-    <td><%= f.text_field :last_name_kana %></td>
-    <td><%= f.text_field :first_name_kana %></td>
-  </tr>
-  <tr>
-    <th>郵便番号</th>
-    <td><%= f.text_field :postal_code %></td>
-  </tr>
-  <tr>
-    <th>住所</th>
-    <td><%= f.text_field :address %></td>
-  </tr>
-  <tr>
-    <th>電話番号</th>
-    <td><%= f.text_field :phone_number %></td>
-  </tr>
-  <tr>
-    <th>メールアドレス</th>
-    <td><%= f.email_field :email_address %></td>
-  </tr>
-  <tr>
-    <th>会員ステータス</th>
-    <td>
-      <%= f.radio_button :is_active, true %>
-      <%= f.label :is_active, "有効" %>
-      <%= f.radio_button :is_active, false %>
-      <%= f.label :is_active, "退会" %>
-    </td>
-  </tr>
-</table>
-
-<%= f.submit "変更を保存", class: "btn btn-success" %>
+  <table class="table table-borderless w-75 mt-4">
+    <tbody>
+      <tr>
+        <th class="pb-3" style="width: 150px;">会員ID</th>
+        <td class="pb-3"><%= @customer.id %></td>
+      </tr>
+      <tr>
+        <th>氏名</th>
+        <td>
+          <%= f.text_field :last_name, class: "form-control d-inline w-auto me-5" %>
+          <%= f.text_field :first_name, class: "form-control d-inline w-auto" %>
+        </td>
+      </tr>
+      <tr>
+        <th>フリガナ</th>
+        <td>
+          <%= f.text_field :last_name_kana, class: "form-control d-inline w-auto me-5" %>
+          <%= f.text_field :first_name_kana, class: "form-control d-inline w-auto" %>
+        </td>
+      </tr>
+      <tr>
+        <th>郵便番号</th>
+        <td><%= f.text_field :postal_code, class: "form-control w-auto" %></td>
+      </tr>
+      <tr>
+        <th>住所</th>
+        <td><%= f.text_field :address, class: "form-control w-75" %></td>
+      </tr>
+      <tr>
+        <th>電話番号</th>
+        <td><%= f.text_field :phone_number, class: "form-control w-auto" %></td>
+      </tr>
+      <tr>
+        <th>メールアドレス</th>
+        <td><%= f.email_field :email_address, class: "form-control w-auto" %></td>
+      </tr>
+      <tr>
+        <th>会員ステータス</th>
+        <td>
+          <%= f.radio_button :is_active, true %>
+          <%= f.label :is_active, "有効" %>
+          <%= f.radio_button :is_active, false %>
+          <%= f.label :is_active, "退会" %>
+        </td>
+      </tr>
+      <tr>
+        <th class="pt-3"></th>
+        <td class="pt-3"><%= f.submit "変更を保存", class: "btn btn-success" %></td>
+      </tr>
+    </tbody>
+  </table>
 <% end %>

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -1,8 +1,8 @@
-<h2>会員一覧</h2>
+<span class="bg-light px-3 fs-5 fw-bold">会員一覧</span>
 
-<table>
+<table class="table w-75 mt-3 mx-auto">
   <thead>
-    <tr>
+    <tr class="table-light">
       <th>会員ID</th>
       <th>氏名</th>
       <th>メールアドレス</th>
@@ -11,16 +11,23 @@
   </thead>
 
   <tbody>
-  <% @customers.each do |customer| %>
-    <tr>
-      <td><%= customer.id %></td>
-      <td><%= link_to customer.last_name + customer.first_name, admin_customer_path(customer) %></td>
-      <td><%= customer.email_address %></td>
-      <td><%= customer.is_active ? "有効" : "退会" %></td>
-    </tr>
-  <% end %>
+    <% @customers.each do |customer| %>
+      <tr>
+        <td><%= customer.id %></td>
+        <td><%= link_to customer.last_name + customer.first_name, admin_customer_path(customer), class: "text-decoration-underline" %></td>
+        <td><%= customer.email_address %></td>
+        <td>
+          <% if customer.is_active %>
+            <span class="text-success fw-bold">有効</span>
+          <% else %>
+            <span class="text-secondary">退会</span>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
   </tbody>
 </table>
 
-<%= paginate @customers %>
-
+<div class="d-flex justify-content-center mt-4">
+  <%= paginate @customers %>
+</div>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -36,6 +36,6 @@
 </table>
 
 <%= link_to "編集する", edit_admin_customer_path(@customer), class: "btn btn-success" %>
-<%= link_to "注文履歴一覧を見る", admin_order_path(@customer), class: "btn btn-primary" %>
+<%= link_to "注文履歴一覧を見る", admin_orders_path, class: "btn btn-primary" %>
 
 </table>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,41 +1,51 @@
-<h3><%= @customer.last_name + @customer.first_name + "さんの会員詳細" %></h3>
+<span class="bg-light px-3 fs-5 fw-bold"><%= @customer.last_name + @customer.first_name %>さんの会員詳細</span>
 
-<table>
-  <tr>
-    <th>会員ID</th>
-    <td><%= @customer.id %></td>
-  </tr>
-  <tr>
-    <th>氏名</th>
-    <td><%= @customer.last_name %> <%= @customer.first_name %></td>
-  </tr>
-  <tr>
-    <th>フリガナ</th>
-    <td><%= @customer.last_name_kana %> <%= @customer.first_name_kana %></td>
-  </tr>
-  <tr>
-    <th>郵便番号</th>
-    <td><%= @customer.postal_code %></td>
-  </tr>
-  <tr>
-    <th>住所</th>
-    <td><%= @customer.address %></td>
-  </tr>
-  <tr>
-    <th>電話番号</th>
-    <td><%= @customer.phone_number %></td>
-  </tr>
-  <tr>
-    <th>メールアドレス</th>
-    <td><%= @customer.email_address %></td>
-  </tr>
-  <tr>
-    <th>会員ステータス</th>
-    <td><%= @customer.is_active ? "有効" : "退会" %></td>
-  </tr>
-</table>
-
-<%= link_to "編集する", edit_admin_customer_path(@customer), class: "btn btn-success" %>
-<%= link_to "注文履歴一覧を見る", admin_orders_path, class: "btn btn-primary" %>
-
+<table class="table table-borderless w-75 mt-3">
+  <tbody>
+    <tr>
+      <th class="table-light" style="width: 200px;">会員ID</th>
+      <td><%= @customer.id %></td>
+    </tr>
+    <tr>
+      <th class="table-light">氏名</th>
+      <td><%= @customer.last_name %> <%= @customer.first_name %></td>
+    </tr>
+    <tr>
+      <th class="table-light">フリガナ</th>
+      <td><%= @customer.last_name_kana %> <%= @customer.first_name_kana %></td>
+    </tr>
+    <tr>
+      <th class="table-light">郵便番号</th>
+      <td><%= @customer.postal_code %></td>
+    </tr>
+    <tr>
+      <th class="table-light">住所</th>
+      <td><%= @customer.address %></td>
+    </tr>
+    <tr>
+      <th class="table-light">電話番号</th>
+      <td><%= @customer.phone_number %></td>
+    </tr>
+    <tr>
+      <th class="table-light">メールアドレス</th>
+      <td><%= @customer.email_address %></td>
+    </tr>
+    <tr>
+      <th class="table-light">会員ステータス</th>
+      <td>
+        <% if @customer.is_active %>
+          <span class="text-success fw-bold">有効</span>
+        <% else %>
+          <span class="text-secondary">退会</span>
+        <% end %>
+      </td>
+    </tr>
+    <tr>
+      <td></td>
+      <td>
+        <%= link_to "編集する", edit_admin_customer_path(@customer), class: "btn btn-success me-5" %>
+        <%= link_to "注文履歴一覧を見る", admin_orders_path, class: "btn btn-primary" %>
+      </td>
+    </tr>
+  </tbody>
 </table>

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,8 +1,8 @@
 <span class="bg-light px-3 fs-5 fw-bold">ジャンル編集</span>
 
-<div class="mt-3">
+<div class="mt-5 w-100">
   <%= form_with model: @genre, url: admin_genre_path(@genre), method: :patch do |f| %>
-    <div class="d-flex gap-2 align-items-center">
+    <div class="d-flex gap-5 align-items-center">
       <label class="form-label mt-2">ジャンル名</label>
       <%= f.text_field :name, class: "form-control w-25" %>
       <%= f.submit "変更を保存", class: "btn btn-success" %>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,19 +1,19 @@
 <span class="bg-light px-3 fs-5 fw-bold">ジャンル一覧・追加</span>
 
-<div class="d-flex align-items-center mt-3 mb-3">
+<div class="d-flex align-items-center mt-5 mb-3">
   <%= form_with model: @genre, url: admin_genres_path do |f| %>
-    <div class="d-flex gap-2">
-      <label class="form-label mt-2">ジャンル名</label>
+    <div class="d-flex gap-5 ">
+      <label class="form-label text-nowrap mt-2">ジャンル名</label>
       <%= f.text_field :name, class: "form-control", placeholder: "ジャンル名" %>
       <%= f.submit "新規登録", class: "btn btn-success" %>
     </div>
   <% end %>
 </div>
 
-<table class="table table-bordered w-50">
+<table class="table w-25 mt-5">
   <thead>
-    <tr>
-      <th class="table-light">ジャンル</th>
+    <tr class="table-light">
+      <th>ジャンル</th>
       <th></th>
     </tr>
   </thead>

--- a/app/views/admin/items/edit.html.erb
+++ b/app/views/admin/items/edit.html.erb
@@ -1,7 +1,7 @@
 <span class="bg-light px-3 fs-5 fw-bold">商品編集</span>
 
 <%= form_with model: @item, url: admin_item_path(@item), method: :patch, local: true do |f| %>
-  <table class="table table-borderless w-75 mt-3">
+  <table class="table table-borderless w-50 mx-auto mt-3">
     <tbody>
       <tr>
         <th class="table-light">商品画像</th>
@@ -20,14 +20,14 @@
         <td>
           <%= f.collection_select :genre_id, @genres, :id, :name,
             {},
-            { class: "form-select w-50" } %>
+            { class: "form-select w-100" } %>
         </td>
       </tr>
       <tr>
         <th class="table-light">税抜価格</th>
         <td>
-          <div class="d-flex align-items-center gap-2">
-            <%= f.number_field :price, class: "form-control w-25" %>
+          <div class="d-flex align-items-center gap-2 w-100">
+            <%= f.number_field :price, class: "form-control" %>
             <span>円</span>
           </div>
         </td>

--- a/app/views/admin/items/index.html.erb
+++ b/app/views/admin/items/index.html.erb
@@ -17,7 +17,7 @@
     <% @items.each do |item| %>
       <tr>
         <td><%= item.id %></td>
-        <td><%= link_to item.name, admin_item_path(item) %></td>
+        <td><%= link_to item.name, admin_item_path(item), class: "text-decoration-underline" %></td>
         <td><%= number_with_delimiter(item.price) %></td>
         <td><%= item.genre.name %></td>
         <td>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,7 +1,7 @@
 <span class="bg-light px-3 fs-5 fw-bold">商品新規登録</span>
 
 <%= form_with model: @item, url: admin_items_path, method: :post, local: true do |f| %>
-  <table class="table table-borderless w-75 mt-3">
+  <table class="table table-borderless w-50 mx-auto mt-3">
     <tbody>
       <tr>
         <th>商品画像</th>
@@ -20,14 +20,14 @@
         <td>
           <%= f.collection_select :genre_id, @genres, :id, :name,
             { include_blank: "-- 選択してください --" },
-            { class: "form-select w-50" } %>
+            { class: "form-select w-100" } %>
         </td>
       </tr>
       <tr>
         <th>税抜価格</th>
         <td>
           <div class="d-flex align-items-center gap-2">
-            <%= f.number_field :price, class: "form-control w-25", placeholder: "1000" %>
+            <%= f.number_field :price, class: "form-control w-100", placeholder: "1000" %>
             <span>円</span>
           </div>
         </td>

--- a/app/views/admin/items/show.html.erb
+++ b/app/views/admin/items/show.html.erb
@@ -1,6 +1,6 @@
 <span class="bg-light px-3 fs-5 fw-bold">商品詳細</span>
 
-<div class="d-flex gap-5 mt-4">
+<div class="d-flex gap-5 mt-5">
   <%# 商品画像 %>
   <div>
     <% if @item.image.attached? %>
@@ -26,7 +26,7 @@
         <td><%= @item.genre.name %></td>
       </tr>
       <tr>
-        <th class="text-muted">税込価格（税抜価格）</th>
+        <th class="text-muted">税込価格<br>（税抜価格）</th>
         <td>
           <%= number_with_delimiter((@item.price * 1.1).ceil) %>
           （<%= number_with_delimiter(@item.price) %>）円

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,11 +1,11 @@
-<span class="bg-light text-brack px-3 mt-3 fs-5 fw-bold">注文履歴一覧</span>
-<table class="table table-hover mt-3">
+<span class="bg-light px-3 mt-3 fs-5 fw-bold">注文履歴一覧</span>
+<table class="table table-hover mt-3 w-75 mx-auto">
   <thead class="table-secondary">
     <tr>
-      <th>購入日時</th>
+      <th style="width: 250px;">購入日時</th>
       <th>購入者</th>
       <th>注文個数</th>
-      <th>注文ステータス</th>
+      <th style="width: 200px;">注文ステータス</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/admin/orders/index.html.erb
+++ b/app/views/admin/orders/index.html.erb
@@ -1,7 +1,6 @@
-<span class="bg-light px-3 fs-5 fw-bold">注文履歴一覧</span>
-
+<span class="bg-light text-brack px-3 mt-3 fs-5 fw-bold">注文履歴一覧</span>
 <table class="table table-hover mt-3">
-  <thead>
+  <thead class="table-secondary">
     <tr>
       <th>購入日時</th>
       <th>購入者</th>
@@ -12,7 +11,7 @@
   <tbody>
     <% @orders.each do |order| %>
       <tr>
-        <td><%= link_to order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admin_order_path(order) %></td>
+        <td><%= link_to order.created_at.strftime("%Y/%m/%d %H:%M:%S"), admin_order_path(order), class: "text-decoration-underline" %></td>
         <td><%= order.customer.last_name %> <%= order.customer.first_name %></td>
         <td><%= order.order_details.sum(:amount) %></td>
         <td><%= order.status %></td>
@@ -20,7 +19,6 @@
     <% end %>
   </tbody>
 </table>
-
 <div class="d-flex justify-content-center mt-4">
   <%= paginate @orders %>
 </div>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,28 +1,28 @@
 <span class="bg-light px-3 fs-5 fw-bold">注文履歴詳細</span>
 
-<table class="table table-borderless w-75 mt-3">
+<table class="table table-borderless w-50 mt-3">
   <tbody>
     <tr>
-      <th class="text-muted">購入者</th>
+      <th style="width: 150px;">購入者</th>
       <td><%= @order.customer.last_name %> <%= @order.customer.first_name %></td>
     </tr>
     <tr>
-      <th class="text-muted">注文日</th>
+      <th>注文日</th>
       <td><%= @order.created_at.strftime("%Y/%m/%d") %></td>
     </tr>
     <tr>
-      <th class="text-muted">配送先</th>
+      <th>配送先</th>
       <td>
         〒<%= @order.postal_code %> <%= @order.address %><br>
         <%= @order.name %>
       </td>
     </tr>
     <tr>
-      <th class="text-muted">支払方法</th>
+      <th>支払方法</th>
       <td><%= @order.payment_method %></td>
     </tr>
     <tr>
-      <th class="text-muted">注文ステータス</th>
+      <th>注文ステータス</th>
       <td>
         <%= form_with model: @order, url: admin_order_path(@order), method: :patch do |f| %>
           <%= f.select :status, Order.statuses.keys, {}, { class: "form-select d-inline w-auto" } %>
@@ -33,14 +33,15 @@
   </tbody>
 </table>
 
+<div class="d-flex align-items-end mt-3">
 <%# 注文明細 %>
-<table class="table table-hover mt-3">
+<table class="table table-hover mt-3 w-auto me-5">
   <thead>
-    <tr>
-      <th>商品名</th>
-      <th>単価（税込）</th>
-      <th>数量</th>
-      <th>小計</th>
+    <tr class="table-light">
+      <th style="width: 250px;">商品名</th>
+      <th style="width: 150px;">単価（税込）</th>
+      <th style="width: 100px;">数量</th>
+      <th style="width: 100px;">小計</th>
       <th>製作ステータス</th>
     </tr>
   </thead>
@@ -53,7 +54,7 @@
         <td><%= number_with_delimiter((detail.price * detail.amount * 1.1).ceil) %></td>
         <td>
           <%= form_with model: detail, url: admin_order_detail_path(@order, detail), method: :patch do |f| %>
-            <%= f.select :making_status, OrderDetail.making_statuses.keys, {}, { class: "form-select d-inline w-auto" } %>
+            <%= f.select :making_status, OrderDetail.making_statuses.keys, {}, { class: "form-select d-inline w-auto me-3" } %>
             <%= f.submit "更新", class: "btn btn-success btn-sm" %>
           <% end %>
         </td>
@@ -62,9 +63,21 @@
   </tbody>
 </table>
 
-<%# 合計金額 %>
-<div class="text-end w-75 mt-3">
-  <p>商品合計　<%= number_with_delimiter(@order.order_details.sum { |d| (d.price * d.amount * 1.1).ceil }) %>円</p>
-  <p>送料　<%= number_with_delimiter(@order.shopping_cost) %>円</p>
-  <p class="fw-bold">請求金額合計　<%= number_with_delimiter(@order.order_details.sum { |d| (d.price * d.amount * 1.1).ceil } + @order.shopping_cost) %>円</p>
+  <%# 合計金額 %>
+  <div class="ms-4 mt-3">
+    <table class="table table-borderless">
+      <tr>
+        <td class="fw-bold">商品合計</td>
+        <td class="text-end"><%= number_with_delimiter(@order.order_details.sum { |d| (d.price * d.amount * 1.1).ceil }) %>円</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">送料</td>
+        <td class="text-end"><%= number_with_delimiter(@order.shopping_cost) %>円</td>
+      </tr>
+      <tr>
+        <td class="fw-bold">請求金額合計</td>
+        <td class="fw-bold text-end"><%= number_with_delimiter(@order.order_details.sum { |d| (d.price * d.amount * 1.1).ceil } + @order.shopping_cost) %>円</td>
+      </tr>
+    </table>
+  </div>
 </div>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,18 +1,28 @@
-<%# app/views/admin/sessions/new.html.erb %>
-<h2>管理者ログイン</h2>
+<h5 class="mt-3 ms-5 px-3 fs-5 fw-bold"><span class="bg-light text-black px-3 py-1 fw-bold">管理者ログイン</span></h5>
 
-<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+<div class="mx-auto" style="max-width: 500px;">
+  <%= tag.div(flash[:alert], class: "alert alert-danger mt-3") if flash[:alert] %>
 
-<%= form_with url: admin_session_path do |f| %>
-  <div>
-    <%= f.label :email_address, "メールアドレス" %>
-    <%= f.email_field :email_address, placeholder: "sample@example.com", required: true, autofocus: true %>
-  </div>
-
-  <div>
-    <%= f.label :password, "パスワード" %>
-    <%= f.password_field :password, required: true %>
-  </div>
-
-  <%= f.submit "ログイン", class: "btn btn-primary" %>
-<% end %>
+  <%= form_with url: admin_session_path do |f| %>
+    <table class="mt-3" style="width: 100%;">
+      <tr>
+        <th class="py-2 pe-3 fw-normal text-nowrap" style="width: 200px;">メールアドレス</th>
+        <td class="py-2">
+          <%= f.email_field :email_address, placeholder: "sample@example.com", required: true, autofocus: true, class: "form-control" %>
+        </td>
+      </tr>
+      <tr>
+        <th class="py-2 pe-3 fw-normal text-nowrap">パスワード</th>
+        <td class="py-2">
+          <%= f.password_field :password, required: true, class: "form-control" %>
+        </td>
+      </tr>
+      <tr>
+        <td></td>
+        <td class="py-2">
+          <%= f.submit "ログイン", class: "btn btn-primary" %>
+        </td>
+      </tr>
+    </table>
+  <% end %>
+</div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -16,7 +16,7 @@
     <div>
       <%= link_to admin_orders_path, style: "text-decoration: none;" do %>
         <div style="width: 150px; height: 50px; border: 2px solid #000; display: flex; align-items: center; justify-content: center; font-weight: bold; color: #000;">
-        LOGO(管理者)
+        LOGO
         </div>
       <% end %>
     </div>
@@ -26,13 +26,19 @@
           <%= link_to "会員一覧", admin_customers_path, class: "btn btn-light me-4", style: "width: 90px;" %>
           <%= link_to "注文履歴一覧", admin_orders_path, class: "btn btn-light me-4", style: "width: 130px;" %>
           <%= link_to "ジャンル一覧", admin_genres_path, class: "btn btn-light me-4", style: "width: 130px;" %>
-          <%= link_to "ログアウト", admin_session_path, data: { turbo_method: :delete }, class: "btn btn-light me-4", style: "width: 90px;" %>
+          <%= link_to "ログアウト", admin_session_path, data: { turbo_method: :delete }, class: "btn btn-light me-4", style: "width: 130px;" %>
         <% else %>
           <%= link_to "About", about_path, class: "btn btn-light me-4", style: "width: 90px;" %>
           <%= link_to "商品一覧", admin_items_path, class: "btn btn-light me-4", style: "width: 90px;" %>
           <%= link_to "新規登録", customers_sign_up_path, class: "btn btn-light me-4", style: "width: 90px;" %>
           <%= link_to "ログイン", new_admin_session_path, class: "btn btn-light me-4", style: "width: 90px;" %>
         <% end %>
+
+        <%# 検索窓（ダミー） %>
+        <div class="d-flex justify-content-end mt-2 me-4">
+          <input type="text" class="form-control" placeholder="Search" style="width: 200px;">
+          <button class="btn btn-outline-secondary" type="button">🔍</button>
+        </div>
       </nav>
     </header>
 


### PR DESCRIPTION
## 実装内容

### ログインページ
- テーブルを使ったフォームレイアウトに変更
- ラベルと入力欄を綺麗に揃えた

### 商品関連ページ
- 商品一覧・詳細・新規登録・編集ページのレイアウトを統一
- `span` でタイトルのスタイルを統一
- テーブルにBootstrapのクラスを追加
- フォームの幅を調整

### 会員関連ページ
- 会員一覧・詳細・編集ページのレイアウトを統一
- ページネーションを10件表示に設定

### 注文履歴関連ページ
- 注文明細テーブルと合計金額を横並びに配置
- 合計金額をテーブルで金額を右揃えに

### ジャンル関連ページ
- ジャンル一覧・編集ページのレイアウトを整備

### ヘッダー
- 検索窓（ダミー）を追加
- ナビゲーションを2行構造に変更