### PR TITLE
[Fix] Name_Error

### DIFF
--- a/test/controllers/admin/homes_controller_test.rb
+++ b/test/controllers/admin/homes_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::HomesControllerTest < ActionDispatch::IntegrationTest
   test "should get top" do
-    get admin_homes_top_url
+    get admin_url
     assert_response :success
   end
 end

--- a/test/controllers/admin/homes_controller_test.rb
+++ b/test/controllers/admin/homes_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::HomesControllerTest < ActionDispatch::IntegrationTest
   test "should get top" do
-    get admin_url
+    get admin_top_url
     assert_response :success
   end
 end


### PR DESCRIPTION
## 対応内容

### Admin::HomesControllerTestの修正
- 存在しないURLヘルパー `admin_homes_top_url` を `admin_url` に修正