### PR TITLE
Fix failing tests

### DIFF
--- a/test/controllers/admin/customers_controller_test.rb
+++ b/test/controllers/admin/customers_controller_test.rb
@@ -1,23 +1,30 @@
 require "test_helper"
 
 class Admin::CustomersControllerTest < ActionDispatch::IntegrationTest
+  include AdminSignInHelper
+
+  setup do
+    @admin = admins(:one)
+    sign_in_as_admin(@admin)
+  end
+
   test "should get index" do
     get admin_customers_index_url
     assert_response :success
   end
 
   test "should get show" do
-    get admin_customers_show_url
+    get admin_customer_url(customers(:one))
     assert_response :success
   end
 
   test "should get edit" do
-    get admin_customers_edit_url
+    get edit_admin_customer_url(customers(:one))
     assert_response :success
   end
 
   test "should get update" do
-    get admin_customers_update_url
-    assert_response :success
+    patch admin_customer_update_url(customers(:one)), params: { customer: { email_address: customers(:one).email_address } }
+    assert_response :redirect
   end
 end

--- a/test/controllers/admin/genres_controller_test.rb
+++ b/test/controllers/admin/genres_controller_test.rb
@@ -1,23 +1,30 @@
 require "test_helper"
 
 class Admin::GenresControllerTest < ActionDispatch::IntegrationTest
+  include AdminSignInHelper
+
+  setup do
+    @admin = admins(:one)
+    sign_in_as_admin(@admin)
+  end
+
   test "should get index" do
     get admin_genres_index_url
     assert_response :success
   end
 
   test "should get create" do
-    get admin_genres_create_url
-    assert_response :success
+    post admin_genres_url, params: { genre: { name: "Test Genre" } }
+    assert_response :redirect
   end
 
   test "should get edit" do
-    get admin_genres_edit_url
+    get edit_admin_genre_url(genres(:one))
     assert_response :success
   end
 
   test "should get update" do
-    get admin_genres_update_url
-    assert_response :success
+    patch admin_genre_url(genres(:one)), params: { genre: { name: "Updated Genre" } }
+    assert_response :redirect
   end
 end

--- a/test/controllers/admin/homes_controller_test.rb
+++ b/test/controllers/admin/homes_controller_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class Admin::HomesControllerTest < ActionDispatch::IntegrationTest
+  include AdminSignInHelper
+
+  setup do
+    @admin = admins(:one)
+    sign_in_as_admin(@admin)
+  end
+
   test "should get top" do
     get admin_top_url
     assert_response :success

--- a/test/controllers/admin/items_controller_test.rb
+++ b/test/controllers/admin/items_controller_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
+  include AdminSignInHelper
+
+  setup do
+    @admin = admins(:one)
+    sign_in_as_admin(@admin)
+  end
+
   test "should get index" do
     get admin_items_index_url
     assert_response :success
@@ -12,22 +19,22 @@ class Admin::ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get create" do
-    get admin_items_create_url
-    assert_response :success
+    post admin_items_url, params: { item: { name: "Test Item", introduction: "Test intro", genre_id: genres(:one).id, price: 100, is_active: true } }
+    assert_response :redirect
   end
 
   test "should get show" do
-    get admin_items_show_url
+    get admin_item_url(items(:one))
     assert_response :success
   end
 
   test "should get edit" do
-    get admin_items_edit_url
+    get edit_admin_item_url(items(:one))
     assert_response :success
   end
 
   test "should get update" do
-    get admin_items_update_url
-    assert_response :success
+    patch admin_item_url(items(:one)), params: { item: { name: "Updated Item", introduction: "Updated intro", genre_id: genres(:one).id, price: 200, is_active: true } }
+    assert_response :redirect
   end
 end

--- a/test/controllers/admin/order_details_controller_test.rb
+++ b/test/controllers/admin/order_details_controller_test.rb
@@ -1,8 +1,15 @@
 require "test_helper"
 
 class Admin::OrderDetailsControllerTest < ActionDispatch::IntegrationTest
+  include AdminSignInHelper
+
+  setup do
+    @admin = admins(:one)
+    sign_in_as_admin(@admin)
+  end
+
   test "should get update" do
-    get admin_order_details_update_url
-    assert_response :success
+    patch admin_order_detail_url(order_id: orders(:one).id, id: order_details(:one).id), params: { order_detail: { making_status: "製作待ち" } }
+    assert_response :redirect
   end
 end

--- a/test/controllers/admin/orders_controller_test.rb
+++ b/test/controllers/admin/orders_controller_test.rb
@@ -1,13 +1,20 @@
 require "test_helper"
 
 class Admin::OrdersControllerTest < ActionDispatch::IntegrationTest
+  include AdminSignInHelper
+
+  setup do
+    @admin = admins(:one)
+    sign_in_as_admin(@admin)
+  end
+
   test "should get show" do
-    get admin_orders_show_url
+    get admin_order_url(orders(:one))
     assert_response :success
   end
 
   test "should get update" do
-    get admin_orders_update_url
-    assert_response :success
+    patch admin_order_url(orders(:one)), params: { order: { status: "入金確認" } }
+    assert_response :redirect
   end
 end

--- a/test/controllers/public/addresses_controller_test.rb
+++ b/test/controllers/public/addresses_controller_test.rb
@@ -1,28 +1,35 @@
 require "test_helper"
 
 class Public::AddressesControllerTest < ActionDispatch::IntegrationTest
+  include CustomerSignInHelper
+
+  setup do
+    @customer = customers(:one)
+    sign_in_as_customer(@customer)
+  end
+
   test "should get index" do
     get public_addresses_index_url
     assert_response :success
   end
 
   test "should get edit" do
-    get public_addresses_edit_url
+    get edit_address_url(addresses(:one))
     assert_response :success
   end
 
   test "should get create" do
-    get public_addresses_create_url
-    assert_response :success
+    post addresses_url, params: { address: { postal_code: "123-4567", address: "Tokyo", name: "Test" } }
+    assert_response :redirect
   end
 
   test "should get update" do
-    get public_addresses_update_url
-    assert_response :success
+    patch address_url(addresses(:one)), params: { address: { postal_code: "123-4567", address: "Osaka", name: "Updated" } }
+    assert_response :redirect
   end
 
   test "should get destroy" do
-    get public_addresses_destroy_url
-    assert_response :success
+    delete address_url(addresses(:one))
+    assert_response :redirect
   end
 end

--- a/test/controllers/public/cart_items_controller_test.rb
+++ b/test/controllers/public/cart_items_controller_test.rb
@@ -1,28 +1,35 @@
 require "test_helper"
 
 class Public::CartItemsControllerTest < ActionDispatch::IntegrationTest
+  include CustomerSignInHelper
+
+  setup do
+    @customer = customers(:one)
+    sign_in_as_customer(@customer)
+  end
+
   test "should get index" do
     get public_cart_items_index_url
     assert_response :success
   end
 
   test "should get create" do
-    get public_cart_items_create_url
-    assert_response :success
+    post cart_items_url, params: { cart_item: { item_id: items(:one).id, amount: 1 } }
+    assert_response :redirect
   end
 
   test "should get update" do
-    get public_cart_items_update_url
-    assert_response :success
+    patch cart_item_url(cart_items(:one)), params: { cart_item: { amount: 2 } }
+    assert_response :redirect
   end
 
   test "should get destroy" do
-    get public_cart_items_destroy_url
-    assert_response :success
+    delete cart_item_url(cart_items(:one))
+    assert_response :redirect
   end
 
   test "should get destroy_all" do
-    get public_cart_items_destroy_all_url
-    assert_response :success
+    delete destroy_all_cart_items_url
+    assert_response :redirect
   end
 end

--- a/test/controllers/public/customers_controller_test.rb
+++ b/test/controllers/public/customers_controller_test.rb
@@ -1,6 +1,13 @@
 require "test_helper"
 
 class Public::CustomersControllerTest < ActionDispatch::IntegrationTest
+  include CustomerSignInHelper
+
+  setup do
+    @customer = customers(:one)
+    sign_in_as_customer(@customer)
+  end
+
   test "should get show" do
     get public_customers_show_url
     assert_response :success
@@ -12,8 +19,8 @@ class Public::CustomersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get update" do
-    get public_customers_update_url
-    assert_response :success
+    patch "/customers/information", params: { customer: { email_address: @customer.email_address } }
+    assert_response :redirect
   end
 
   test "should get unsubscribe" do
@@ -23,6 +30,6 @@ class Public::CustomersControllerTest < ActionDispatch::IntegrationTest
 
   test "should get withdraw" do
     get public_customers_withdraw_url
-    assert_response :success
+    assert_response :redirect
   end
 end

--- a/test/controllers/public/items_controller_test.rb
+++ b/test/controllers/public/items_controller_test.rb
@@ -7,7 +7,7 @@ class Public::ItemsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get show" do
-    get public_items_show_url
+    get item_url(items(:one))
     assert_response :success
   end
 end

--- a/test/controllers/public/orders_controller_test.rb
+++ b/test/controllers/public/orders_controller_test.rb
@@ -1,24 +1,31 @@
 require "test_helper"
 
 class Public::OrdersControllerTest < ActionDispatch::IntegrationTest
+  include CustomerSignInHelper
+
+  setup do
+    @customer = customers(:one)
+    sign_in_as_customer(@customer)
+  end
+
   test "should get new" do
-    get public_orders_new_url
+    get orders_new_url
     assert_response :success
   end
 
   test "should get confirm" do
-    get public_orders_confirm_url
+    post orders_confirm_url, params: { order: { postal_code: "123-4567", address: "Tokyo", name: "Test Name" } }
     assert_response :success
   end
 
   test "should get thanks" do
-    get public_orders_thanks_url
+    get orders_thanks_url
     assert_response :success
   end
 
   test "should get create" do
-    get public_orders_create_url
-    assert_response :success
+    post orders_url, params: { order: { postal_code: "123-4567", address: "Tokyo", name: "Test Name" } }
+    assert_response :redirect
   end
 
   test "should get index" do
@@ -27,7 +34,7 @@ class Public::OrdersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get show" do
-    get public_orders_show_url
+    get order_url(orders(:one))
     assert_response :success
   end
 end

--- a/test/fixtures/admins.yml
+++ b/test/fixtures/admins.yml
@@ -2,8 +2,8 @@
 
 one:
   email_address: admin1@example.com
-  password_digest: password_digest
+  password_digest: <%= BCrypt::Password.create("password") %>
 
 two:
   email_address: admin2@example.com
-  password_digest: password_digest
+  password_digest: <%= BCrypt::Password.create("password") %>

--- a/test/fixtures/cart_items.yml
+++ b/test/fixtures/cart_items.yml
@@ -1,11 +1,11 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  item_id: 1
-  customer_id: 1
+  item: one
+  customer: one
   amount: 1
 
 two:
-  item_id: 1
-  customer_id: 1
+  item: one
+  customer: one
   amount: 1

--- a/test/fixtures/customers.yml
+++ b/test/fixtures/customers.yml
@@ -1,7 +1,21 @@
 one:
   email_address: customer1@example.com
-  password_digest: password_digest
+  password_digest: <%= BCrypt::Password.create("password") %>
+  last_name: 山田
+  first_name: 太郎
+  last_name_kana: ヤマダ
+  first_name_kana: タロウ
+  postal_code: "123-4567"
+  address: 東京都渋谷区
+  phone_number: "090-1234-5678"
 
 two:
   email_address: customer2@example.com
-  password_digest: password_digest
+  password_digest: <%= BCrypt::Password.create("password") %>
+  last_name: 鈴木
+  first_name: 花子
+  last_name_kana: スズキ
+  first_name_kana: ハナコ
+  postal_code: "234-5678"
+  address: 大阪府大阪市
+  phone_number: "090-2345-6789"

--- a/test/fixtures/items.yml
+++ b/test/fixtures/items.yml
@@ -1,14 +1,14 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  genre_id: 1
+  genre: one
   name: MyString
   introduction: MyText
   price: 1
   is_active: false
 
 two:
-  genre_id: 1
+  genre: one
   name: MyString
   introduction: MyText
   price: 1

--- a/test/fixtures/order_details.yml
+++ b/test/fixtures/order_details.yml
@@ -1,15 +1,15 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  order_id: 1
-  item_id: 1
+  order: one
+  item: one
   price: 1
   amount: 1
   making_status: 1
 
 two:
-  order_id: 1
-  item_id: 1
+  order: one
+  item: one
   price: 1
   amount: 1
   making_status: 1

--- a/test/fixtures/orders.yml
+++ b/test/fixtures/orders.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  customer_id: 1
+  customer: one
   postal_code: MyString
   address: MyString
   name: MyString
@@ -11,7 +11,7 @@ one:
   status: 1
 
 two:
-  customer_id: 1
+  customer: one
   postal_code: MyString
   address: MyString
   name: MyString

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,3 +13,15 @@ module ActiveSupport
     # Add more helper methods to be used by all tests here...
   end
 end
+
+module CustomerSignInHelper
+  def sign_in_as_customer(customer)
+    post session_url, params: { email_address: customer.email_address, password: "password" }
+  end
+end
+
+module AdminSignInHelper
+  def sign_in_as_admin(admin)
+    post admin_session_url, params: { email_address: admin.email_address, password: "password" }
+  end
+end


### PR DESCRIPTION
## 修正内容

### 原因
テストにログインセッションの設定がなく、認証が必要なページへのアクセスが
全てリダイレクトされていたため、43テスト中40件が失敗していた。

### 修正内容

**fixtureファイル（6ファイル）**
- IDのハードコード（genre_id: 1）をラベル参照（genre: one）に変更
- customers.yml / admins.yml のpassword_digestをbcryptハッシュに変更

**test_helper.rb**
- CustomerSignInHelper / AdminSignInHelper を追加
- セッションコントローラ経由でのログインヘルパーを実装

**テストファイル（10ファイル）**
- setup でログイン処理を追加
- 正しいルートヘルパーとfixtureIDを使用
- 書き込みアクションのHTTPメソッドとレスポンスを修正

### 結果
43テスト全て通過